### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#GGTabBar
+# GGTabBar
 
 GGTabBar is a *simple* UITabBar & UITabBarController replacement that uses Auto Layout
 for constructing the GUI. I created it for curiosity, but it may be useful


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
